### PR TITLE
Enabled method completion with mock class as string parameter

### DIFF
--- a/src/com/phpuaca/completion/StringLiteralContributor.java
+++ b/src/com/phpuaca/completion/StringLiteralContributor.java
@@ -2,6 +2,7 @@ package com.phpuaca.completion;
 
 import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.project.Project;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiWhiteSpace;
@@ -25,7 +26,8 @@ public class StringLiteralContributor extends CompletionContributor {
                 if (originalPosition != null) {
                     Filter filter = FilterFactory.getInstance().getFilter(originalPosition.getParent());
                     if (filter != null) {
-                        List<LookupElement> elements = (new LookupElementProvider()).find(filter);
+                        Project project = originalPosition.getProject();
+                        List<LookupElement> elements = (new LookupElementProvider()).find(project, filter);
                         completionResultSet.addAllElements(elements);
                     }
                 }

--- a/src/com/phpuaca/completion/filter/Filter.java
+++ b/src/com/phpuaca/completion/filter/Filter.java
@@ -19,6 +19,7 @@ abstract public class Filter {
     private List<String> disallowedMethods;
 
     private ClassConstantReference classConstantReference;
+    private String className;
 
     public Filter(FilterContext context)
     {
@@ -121,5 +122,13 @@ abstract public class Filter {
     public ClassConstantReference getClassConstantReference()
     {
         return classConstantReference;
+    }
+
+    protected void setClassName(String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
     }
 }

--- a/src/com/phpuaca/completion/filter/InvocationMockerFilter.java
+++ b/src/com/phpuaca/completion/filter/InvocationMockerFilter.java
@@ -23,7 +23,12 @@ public class InvocationMockerFilter extends Filter {
                 allowModifier(PhpModifier.PROTECTED_ABSTRACT_DYNAMIC);
                 allowModifier(PhpModifier.PROTECTED_IMPLEMENTED_DYNAMIC);
 
-                setClassConstantReference(classFinderResult.getClassConstantReference());
+                if (classFinderResult.getClassConstantReference() != null) {
+                    setClassConstantReference(classFinderResult.getClassConstantReference());
+                }
+                if (classFinderResult.getClassName() != null) {
+                    setClassName(classFinderResult.getClassName());
+                }
 
                 MethodReference definitionMethodReference = (new PhpMethodChain(methodReference)).findMethodReference("setMethods");
                 if (definitionMethodReference == null) {

--- a/src/com/phpuaca/completion/filter/MockBuilderFilter.java
+++ b/src/com/phpuaca/completion/filter/MockBuilderFilter.java
@@ -21,7 +21,12 @@ public class MockBuilderFilter extends Filter {
 
         ClassFinder.Result classFinderResult = (new ClassFinder()).find(methodReference);
         if (classFinderResult != null) {
-            setClassConstantReference(classFinderResult.getClassConstantReference());
+            if (classFinderResult.getClassConstantReference() != null) {
+                setClassConstantReference(classFinderResult.getClassConstantReference());
+            }
+            if (classFinderResult.getClassName() != null) {
+                setClassName(classFinderResult.getClassName());
+            }
         }
 
         disallowMethod("__construct");

--- a/src/com/phpuaca/completion/provider/LookupElementProvider.java
+++ b/src/com/phpuaca/completion/provider/LookupElementProvider.java
@@ -1,6 +1,7 @@
 package com.phpuaca.completion.provider;
 
 import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.project.Project;
 import com.jetbrains.php.completion.PhpLookupElement;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
 import com.jetbrains.php.lang.psi.elements.Field;
@@ -16,24 +17,33 @@ import java.util.List;
 public class LookupElementProvider {
 
     @NotNull
-    public List<LookupElement> find(@NotNull Filter filter)
+    public List<LookupElement> find(@NotNull Project project, @NotNull Filter filter)
     {
         List<LookupElement> list = new ArrayList<LookupElement>();
         ClassConstantReference classConstantReference = filter.getClassConstantReference();
+        PhpClass resolvedClass = null;
 
         if (classConstantReference != null) {
             PhpClassResolver resolver = new PhpClassResolver(classConstantReference);
             if (resolver.resolve()) {
-                PhpClass resolvedClass = resolver.getResolvedClass();
-                for (Method method : resolvedClass.getMethods()) {
-                    if (filter.isMethodAllowed(method)) {
-                        list.add(new PhpLookupElement(method));
-                    }
+                resolvedClass = resolver.getResolvedClass();
+            }
+        }
+
+        String className = filter.getClassName();
+        if (className != null) {
+            resolvedClass = PhpClassResolver.getClass(project, className);
+        }
+
+        if (resolvedClass != null) {
+            for (Method method : resolvedClass.getMethods()) {
+                if (filter.isMethodAllowed(method)) {
+                    list.add(new PhpLookupElement(method));
                 }
-                for (Field field : resolvedClass.getFields()) {
-                    if (!field.isConstant() && filter.isFieldAllowed(field)) {
-                        list.add(new PhpLookupElement(field));
-                    }
+            }
+            for (Field field : resolvedClass.getFields()) {
+                if (!field.isConstant() && filter.isFieldAllowed(field)) {
+                    list.add(new PhpLookupElement(field));
                 }
             }
         }

--- a/src/com/phpuaca/completion/util/PhpClassResolver.java
+++ b/src/com/phpuaca/completion/util/PhpClassResolver.java
@@ -1,11 +1,14 @@
 package com.phpuaca.completion.util;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
 import com.jetbrains.php.lang.psi.elements.ClassReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
@@ -43,5 +46,16 @@ final public class PhpClassResolver implements IResolver {
     public PhpClass getResolvedClass()
     {
         return resolvedClass;
+    }
+
+    @Nullable
+    static public PhpClass getClass(Project project, String className) {
+        return getClass(PhpIndex.getInstance(project), className);
+    }
+
+    @Nullable
+    static public PhpClass getClass(PhpIndex phpIndex, String className) {
+        Collection<PhpClass> classes = phpIndex.getClassesByFQN(className);
+        return classes.isEmpty() ? null : classes.iterator().next();
     }
 }


### PR DESCRIPTION
This pull-request allows method completion when mocked class is parametrized as string instead of a class constant:

``` php
// MockBuilderFilter

$this->getMockBuilder('\ThomasSchulz\ClockUtil\Clock')
    ->setMethods(array('<caret>'));

$this->getMock('\ThomasSchulz\ClockUtil\Clock', array('<caret>'));
$this->getMockClass('\ThomasSchulz\ClockUtil\Clock', array('<caret>'));
$this->getMockForAbstractClass('\ThomasSchulz\ClockUtil\Clock', 
    array(), '', true, true, true, array('<caret>'));
$this->getMockForTrait('\ThomasSchulz\ClockUtil\Clock', 
    array(), '', true, true, true, array('<caret>'));

// InvocationMockerFilter

$mock = $this->getMockBuilder('\ThomasSchulz\ClockUtil\Clock')
    ->setMethods(array('test1', 'test2'))
    ->getMock();
$mock->expects($this->once())->method('<caret>');
```

It also works with double-quote strings:

``` php
$this->getMock("\\ThomasSchulz\\ClockUtil\\Clock", array('<caret>'));
```
