### PR TITLE
Allow completion of all methods when MockBuilder has no setMethods call

### DIFF
--- a/src/com/phpuaca/completion/filter/InvocationMockerFilter.java
+++ b/src/com/phpuaca/completion/filter/InvocationMockerFilter.java
@@ -28,6 +28,7 @@ public class InvocationMockerFilter extends Filter {
                 MethodReference definitionMethodReference = (new PhpMethodChain(methodReference)).findMethodReference("setMethods");
                 if (definitionMethodReference == null) {
                     definitionMethodReference = methodReference;
+                    allowMethods();
                 }
 
                 ParameterList parameterList = definitionMethodReference.getParameterList();


### PR DESCRIPTION
This change allows method completion of all methods when MockBuilder has no `setMethods` call. (Every method of the class is stubbed in this case)

``` php
$mock = $this->getMockBuilder(\ThomasSchulz\ClockUtil\Clock::class)
             ->getMock();
$mock->expects($this->once())->method('<caret>');
```

Also works:

``` php
$mock = $this->getMock(\ThomasSchulz\ClockUtil\Clock::class);
$mock->expects($this->once())->method('<caret>');
```
