### PR TITLE
Added TypeProvider for mocked classes (getMock/getMockBuilder/prophesize) (solves #5)

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -47,6 +47,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <completion.confidence language="PHP" implementationClass="com.phpuaca.completion.StringLiteralConfidence" id="asTrue" order="first"/>
     <completion.contributor language="PHP" implementationClass="com.phpuaca.completion.StringLiteralContributor"/>
+    <php.typeProvider2 implementation="com.phpuaca.completion.MockedClassTypeProvider"/>
   </extensions>
 
   <application-components>

--- a/src/com/phpuaca/completion/MockedClassTypeProvider.java
+++ b/src/com/phpuaca/completion/MockedClassTypeProvider.java
@@ -1,0 +1,217 @@
+package com.phpuaca.completion;
+
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider2;
+import com.phpuaca.completion.util.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class MockedClassTypeProvider implements PhpTypeProvider2
+{
+    final static char TRIM_KEY = '\u0180';
+
+    @Override
+    public char getKey() {
+        return '\u0150';
+    }
+
+    @Nullable
+    @Override
+    public String getType(PsiElement element) {
+
+        if (DumbService.getInstance(element.getProject()).isDumb() || !(element instanceof MethodReference)) {
+            return null;
+        }
+
+        List<PhpMethodSignature> signatures = getSignatures();
+        if (signatures.size() == 0) {
+            return null;
+        }
+
+        MethodReference methodReference = (MethodReference) element;
+        String refSignature = methodReference.getSignature();
+
+        if (StringUtil.isEmpty(refSignature)) {
+            return null;
+        }
+
+        // Get signature from:  $this->getMockBuilder('CLASS')->getMock()
+        MethodReference mockBuilderMethodReference = (new PhpMethodChain(methodReference)).findMethodReference("getMockBuilder");
+
+        if (mockBuilderMethodReference != null && "getMock".equals(methodReference.getName())) {
+            PsiElement[] mockBuilderParams = mockBuilderMethodReference.getParameters();
+            String signature = buildParameterMethodSignature(refSignature, 0, mockBuilderParams);
+
+            if (signature != null) {
+                return signature;
+            }
+        }
+
+        // Set MethodProphecy signature for:  $prophecy->method()
+        PsiElement child = methodReference.getFirstChild();
+        if (child instanceof Variable) {
+            String expression = ((Variable)child).getType().toString();
+            // get back our original call
+            int endIndex = expression.lastIndexOf(TRIM_KEY);
+            if(endIndex != -1) {
+                PhpIndex phpIndex = PhpIndex.getInstance(element.getProject());
+
+                MethodReference prophesizeMethod = (new PhpVariable((Variable)child)).findClosestAssignment();
+
+                if (prophesizeMethod != null) {
+                    PhpNamedElement prophCall = phpIndex.getBySignature(prophesizeMethod.getSignature()).iterator().next();
+
+                    if(prophCall != null && prophCall.getFQN() != null && prophCall.getFQN().equals("\\PHPUnit_Framework_TestCase.prophesize")) {
+                        String prophType = prophCall.getType().toString();
+                        if(prophType.equals("\\Prophecy\\Prophecy\\ObjectProphecy")) {
+                            if("reveal".equals(methodReference.getName())) {
+                                return buildParameterMethodSignature(refSignature, 0, prophesizeMethod.getParameters());
+                            } else {
+                                // check if methodReference is not in ObjectProphecy (it is a mocked method)
+                                PhpMethodResolver resolver = new PhpMethodResolver(methodReference);
+                                if(resolver.resolve()) {
+                                    String resolvedClass = resolver.getResolvedClass().getFQN();
+                                    if(resolvedClass != null && !resolvedClass.equals("\\Prophecy\\Prophecy\\ObjectProphecy")) {
+                                        return "\\Prophecy\\Prophecy\\MethodProphecy";
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Get signatures like:  $this->getMock('CLASS') ...
+        ArrayList<PhpMethodSignature> matchedSignatures = getMatchedSignatures(methodReference.getName(), signatures);
+        if (matchedSignatures.size() == 0) {
+            return null;
+        }
+
+        PsiElement[] parameters = methodReference.getParameters();
+        for (PhpMethodSignature methodSignature: matchedSignatures) {
+            String signature = buildParameterMethodSignature(refSignature, methodSignature.getParameterIndex(), parameters);
+
+            if (signature != null) {
+                return signature;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends PhpNamedElement> getBySignature(String expression, Project project) {
+
+        PhpIndex phpIndex = PhpIndex.getInstance(project);
+
+        if (expression.equals("\\Prophecy\\Prophecy\\MethodProphecy")) {
+            return phpIndex.getClassesByFQN(expression);
+        }
+
+        // get back our original call
+        int endIndex = expression.lastIndexOf(TRIM_KEY);
+        if (endIndex == -1) {
+            return null;
+        }
+
+        String originalSignature = expression.substring(0, endIndex);
+        String parameter = expression.substring(endIndex + 1);
+
+        Collection<? extends PhpNamedElement> phpNamedElementCollections = phpIndex.getBySignature(originalSignature, null, 0);
+        if (phpNamedElementCollections.size() == 0) {
+            return null;
+        }
+
+        // get first matched item
+        PhpNamedElement phpNamedElement = phpNamedElementCollections.iterator().next();
+        if (!(phpNamedElement instanceof Method)) {
+            return null;
+        }
+
+        List<PhpMethodSignature> signatures = getSignatures();
+        if (signatures.size() == 0) {
+            return null;
+        }
+
+        ArrayList<PhpNamedElement> phpNamedElements = new ArrayList<PhpNamedElement>();
+        phpNamedElements.add(phpNamedElement);
+
+        parameter = PhpTypeProviderUtil.getResolvedParameter(phpIndex, parameter);
+        if (parameter == null) {
+            return phpNamedElementCollections;
+        }
+
+        for (PhpMethodSignature matchedSignature : signatures) {
+            if (PhpUtil.isCallTo((Method) phpNamedElement, matchedSignature.getClassName(), matchedSignature.getMethodName())) {
+                Collection<? extends PhpNamedElement> namedElements = getByParameter(project, parameter);
+                phpNamedElements.addAll(namedElements);
+            }
+        }
+
+        return new ArrayList<PhpNamedElement>(phpNamedElements);
+    }
+
+    private List<PhpMethodSignature> getSignatures() {
+        List<PhpMethodSignature> signatures = new ArrayList<PhpMethodSignature>();
+
+        signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_MockObject_MockBuilder", "getMock", 0));
+        signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "getMock", 0));
+        signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "getMockForAbstractClass", 0));
+        signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "getMockForTrait", 0));
+        signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "prophesize", 0));
+        signatures.add(new PhpMethodSignature("\\Prophecy\\Prophecy\\ObjectProphecy", "reveal", 0));
+
+        return signatures;
+    }
+
+    private ArrayList<PhpMethodSignature> getMatchedSignatures(String methodName, List<PhpMethodSignature> methodSignatureSettingList) {
+
+        ArrayList<PhpMethodSignature> matchedSignatures = new ArrayList<PhpMethodSignature>();
+
+        for(PhpMethodSignature methodSignatureSetting: methodSignatureSettingList) {
+            if(methodSignatureSetting.getMethodName().equals(methodName)) {
+                matchedSignatures.add(methodSignatureSetting);
+            }
+        }
+
+        return matchedSignatures;
+    }
+
+    private String buildParameterMethodSignature(String refSignature, int parameterIndex, PsiElement[] parameters) {
+        if (parameters.length - 1 < parameterIndex) {
+            return null;
+        }
+        PsiElement parameter = parameters[parameterIndex];
+        if ((parameter instanceof StringLiteralExpression)) {
+            String param = ((StringLiteralExpression)parameter).getContents();
+            if (StringUtil.isNotEmpty(param)) {
+                return refSignature + TRIM_KEY + param;
+            }
+        }
+
+        if (parameter instanceof PhpReference && (parameter instanceof ClassConstantReference || parameter instanceof FieldReference)) {
+            String signature = ((PhpReference) parameter).getSignature();
+            if (StringUtil.isNotEmpty(signature)) {
+                return refSignature + TRIM_KEY + signature;
+            }
+        }
+
+        return null;
+    }
+
+    @NotNull
+    private Collection<? extends PhpNamedElement> getByParameter(Project project, String parameter) {
+        return PhpIndex.getInstance(project).getClassesByFQN(parameter.startsWith("\\") ? parameter : "\\" + parameter);
+    }
+
+}

--- a/src/com/phpuaca/completion/MockedClassTypeProvider.java
+++ b/src/com/phpuaca/completion/MockedClassTypeProvider.java
@@ -70,7 +70,8 @@ public class MockedClassTypeProvider implements PhpTypeProvider2
                 if (prophesizeMethod != null) {
                     PhpNamedElement prophCall = phpIndex.getBySignature(prophesizeMethod.getSignature()).iterator().next();
 
-                    if(prophCall != null && prophCall.getFQN() != null && prophCall.getFQN().equals("\\PHPUnit_Framework_TestCase.prophesize")) {
+                    if(prophCall != null && prophCall.getFQN() != null &&
+                            (prophCall.getFQN().equals("\\PHPUnit_Framework_TestCase.prophesize") || prophCall.getFQN().equals("\\Prophecy\\Prophet.prophesize"))) {
                         String prophType = prophCall.getType().toString();
                         if(prophType.equals("\\Prophecy\\Prophecy\\ObjectProphecy")) {
                             if("reveal".equals(methodReference.getName())) {
@@ -169,6 +170,7 @@ public class MockedClassTypeProvider implements PhpTypeProvider2
         signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "getMockForAbstractClass", 0));
         signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "getMockForTrait", 0));
         signatures.add(new PhpMethodSignature("\\PHPUnit_Framework_TestCase", "prophesize", 0));
+        signatures.add(new PhpMethodSignature("\\Prophecy\\Prophet", "prophesize", 0));
         signatures.add(new PhpMethodSignature("\\Prophecy\\Prophecy\\ObjectProphecy", "reveal", 0));
 
         return signatures;
@@ -202,6 +204,12 @@ public class MockedClassTypeProvider implements PhpTypeProvider2
         if (parameter instanceof PhpReference && (parameter instanceof ClassConstantReference || parameter instanceof FieldReference)) {
             String signature = ((PhpReference) parameter).getSignature();
             if (StringUtil.isNotEmpty(signature)) {
+                if (signature.startsWith("#K#C")) {
+                    signature = signature.substring(4);
+                }
+                if (signature.endsWith(".class")) {
+                    signature = signature.substring(0, signature.length()-6);
+                }
                 return refSignature + TRIM_KEY + signature;
             }
         }

--- a/src/com/phpuaca/completion/MockedClassTypeProvider.java
+++ b/src/com/phpuaca/completion/MockedClassTypeProvider.java
@@ -219,7 +219,14 @@ public class MockedClassTypeProvider implements PhpTypeProvider2
 
     @NotNull
     private Collection<? extends PhpNamedElement> getByParameter(Project project, String parameter) {
-        return PhpIndex.getInstance(project).getClassesByFQN(parameter.startsWith("\\") ? parameter : "\\" + parameter);
-    }
+        PhpIndex phpIndex = PhpIndex.getInstance(project);
+        String classFQN = parameter.startsWith("\\") ? parameter : "\\" + parameter;
+        Collection<? extends PhpNamedElement> classes = phpIndex.getClassesByFQN(classFQN);
 
+        if (classes.size() == 0) {
+            classes = phpIndex.getInterfacesByFQN(classFQN);
+        }
+
+        return classes;
+    }
 }

--- a/src/com/phpuaca/completion/util/PhpElementsUtil.java
+++ b/src/com/phpuaca/completion/util/PhpElementsUtil.java
@@ -1,0 +1,127 @@
+package com.phpuaca.completion.util;
+
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Condition;
+import com.intellij.patterns.ElementPattern;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiElementFilter;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.CommonProcessors;
+import com.intellij.util.Processor;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.completion.PhpLookupElement;
+import com.jetbrains.php.lang.PhpLangUtil;
+import com.jetbrains.php.lang.PhpLanguage;
+import com.jetbrains.php.lang.lexer.PhpTokenTypes;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
+import com.jetbrains.php.lang.patterns.PhpPatterns;
+import com.jetbrains.php.lang.psi.PhpFile;
+import com.jetbrains.php.lang.psi.PhpPsiUtil;
+import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class PhpElementsUtil {
+//
+    @Nullable
+    static public Method getClassMethod(PhpClass phpClass, String methodName) {
+        return phpClass.findMethodByName(methodName);
+    }
+//
+    @Nullable
+    static public Method getClassMethod(Project project, String phpClassName, String methodName) {
+
+        // we need here an each; because eg Command is non unique because phar file
+        for(PhpClass phpClass: PhpIndex.getInstance(project).getClassesByFQN(phpClassName)) {
+            Method method = getClassMethod(phpClass, methodName);
+            if(method != null) {
+                return method;
+            }
+        }
+
+        return null;
+    }
+//
+    @Nullable
+    public static String getStringValue(@Nullable PsiElement psiElement) {
+        return getStringValue(psiElement, 0);
+    }
+//
+    @Nullable
+    private static String getStringValue(@Nullable PsiElement psiElement, int depth) {
+
+        if(psiElement == null || ++depth > 5) {
+            return null;
+        }
+
+        if(psiElement instanceof StringLiteralExpression) {
+            String resolvedString = ((StringLiteralExpression) psiElement).getContents();
+            if(StringUtils.isEmpty(resolvedString)) {
+                return null;
+            }
+
+            return resolvedString;
+        }
+
+        if(psiElement instanceof Field) {
+            return getStringValue(((Field) psiElement).getDefaultValue(), depth);
+        }
+
+        if(psiElement instanceof PhpReference) {
+
+            PsiReference psiReference = psiElement.getReference();
+            if(psiReference == null) {
+                return null;
+            }
+
+            PsiElement ref = psiReference.resolve();
+            if(ref instanceof PhpReference) {
+                return getStringValue(psiElement, depth);
+            }
+
+            if(ref instanceof Field) {
+                PsiElement resolved = ((Field) ref).getDefaultValue();
+
+                if(resolved instanceof StringLiteralExpression) {
+                    return ((StringLiteralExpression) resolved).getContents();
+                }
+            }
+
+        }
+
+        return null;
+    }
+
+    public static boolean isEqualClassName(@NotNull PhpClass phpClass, @NotNull PhpClass compareClassName) {
+        return isEqualClassName(phpClass, compareClassName.getPresentableFQN());
+    }
+
+    public static boolean isEqualClassName(@Nullable PhpClass phpClass, @Nullable String compareClassName) {
+
+        if(phpClass == null || compareClassName == null) {
+            return false;
+        }
+
+        String phpClassName = phpClass.getPresentableFQN();
+        if(phpClassName == null) {
+            return false;
+        }
+
+        if(phpClassName.startsWith("\\")) {
+            phpClassName = phpClassName.substring(1);
+        }
+
+        if(compareClassName.startsWith("\\")) {
+            compareClassName = compareClassName.substring(1);
+        }
+
+        return phpClassName.equals(compareClassName);
+    }
+}

--- a/src/com/phpuaca/completion/util/PhpMethodSignature.java
+++ b/src/com/phpuaca/completion/util/PhpMethodSignature.java
@@ -1,0 +1,38 @@
+package com.phpuaca.completion.util;
+
+public class PhpMethodSignature {
+
+    private String className;
+    private String methodName;
+    private int parameterIndex;
+
+    public PhpMethodSignature(String className, String methodName, int parameterIndex) {
+        this.className = className;
+        this.methodName = methodName;
+        this.parameterIndex = parameterIndex;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public void setParameterIndex(int parameterIndex) {
+        this.parameterIndex = parameterIndex;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public int getParameterIndex() {
+        return parameterIndex;
+    }
+}

--- a/src/com/phpuaca/completion/util/PhpTypeProviderUtil.java
+++ b/src/com/phpuaca/completion/util/PhpTypeProviderUtil.java
@@ -1,0 +1,92 @@
+package com.phpuaca.completion.util;
+
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public class PhpTypeProviderUtil {
+
+    @Nullable
+    public static String getReferenceSignature(MethodReference methodReference, char trimKey) {
+        return getReferenceSignature(methodReference, trimKey, 1);
+    }
+
+    @Nullable
+    public static String getReferenceSignature(MethodReference methodReference, char trimKey, int equalParameterCount) {
+
+        String refSignature = methodReference.getSignature();
+        if(StringUtil.isEmpty(refSignature)) {
+            return null;
+        }
+
+        PsiElement[] parameters = methodReference.getParameters();
+        if (parameters.length != equalParameterCount) {
+            return null;
+        }
+
+        PsiElement parameter = parameters[0];
+
+        // we already have a string value
+        if ((parameter instanceof StringLiteralExpression)) {
+            String param = ((StringLiteralExpression)parameter).getContents();
+            if (StringUtil.isNotEmpty(param)) {
+                return refSignature + trimKey + param;
+            }
+
+            return null;
+        }
+
+        // whitelist here; we can also provide some more but think of performance
+        // Service::NAME, $this->name and Entity::CLASS;
+        if (parameter instanceof PhpReference && (parameter instanceof ClassConstantReference || parameter instanceof FieldReference)) {
+            String signature = ((PhpReference) parameter).getSignature();
+            if (StringUtil.isNotEmpty(signature)) {
+                return refSignature + trimKey + signature;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * we can also pipe php references signatures and resolve them here
+     * overwrite parameter to get string value
+     */
+    @Nullable
+    public static String getResolvedParameter(PhpIndex phpIndex, String parameter) {
+
+        // PHP 5.5 class constant: workaround since signature has empty type
+        // #K#C\Class\Foo.
+        if(parameter.startsWith("#K#C") && parameter.endsWith(".")) {
+            return parameter.substring(4, parameter.length() - 1);
+        }
+
+        // #K#C\Class\Foo.property
+        // #K#C\Class\Foo.CONST
+        if(parameter.startsWith("#")) {
+
+            // get psi element from signature
+            Collection<? extends PhpNamedElement> signTypes = phpIndex.getBySignature(parameter, null, 0);
+            if(signTypes.size() == 0) {
+                return null;
+            }
+
+            // get string value
+            parameter = PhpElementsUtil.getStringValue(signTypes.iterator().next());
+            if(parameter == null) {
+                return null;
+            }
+
+        }
+
+        return parameter;
+    }
+
+}

--- a/src/com/phpuaca/completion/util/PhpUtil.java
+++ b/src/com/phpuaca/completion/util/PhpUtil.java
@@ -1,0 +1,114 @@
+package com.phpuaca.completion.util;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.ResolveResult;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.Method;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class PhpUtil {
+
+//
+    protected static boolean isCallTo(Method e, Method[] expectedMethods) {
+
+        PhpClass methodClass = e.getContainingClass();
+        if(methodClass == null) {
+            return false;
+        }
+
+        for (Method expectedMethod : expectedMethods) {
+
+            // @TODO: its stuff from beginning times :)
+            if(expectedMethod == null) {
+                continue;
+            }
+
+            PhpClass containingClass = expectedMethod.getContainingClass();
+            if (containingClass != null && expectedMethod.getName().equals(e.getName()) && isInstanceOf(methodClass, containingClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+//
+    @Nullable
+    protected static Method getInterfaceMethod(Project project, String interfaceFQN, String methodName) {
+
+        Collection<PhpClass> interfaces = PhpIndex.getInstance(project).getInterfacesByFQN(interfaceFQN);
+
+        if (interfaces.size() < 1) {
+            return null;
+        }
+
+        return findClassMethodByName(interfaces.iterator().next(), methodName);
+    }
+//
+    @Nullable
+    protected static Method getClassMethod(Project project, String classFQN, String methodName) {
+        return PhpElementsUtil.getClassMethod(project, classFQN, methodName);
+    }
+//
+    @Nullable
+    protected static Method findClassMethodByName(PhpClass phpClass, String methodName) {
+        return PhpElementsUtil.getClassMethod(phpClass, methodName);
+    }
+
+    protected static boolean isImplementationOfInterface(PhpClass phpClass, PhpClass phpInterface) {
+        if (phpClass == phpInterface) {
+            return true;
+        }
+
+        for (PhpClass implementedInterface : phpClass.getImplementedInterfaces()) {
+            if (isImplementationOfInterface(implementedInterface, phpInterface)) {
+                return true;
+            }
+        }
+
+        if (null == phpClass.getSuperClass()) {
+            return false;
+        }
+
+        return isImplementationOfInterface(phpClass.getSuperClass(), phpInterface);
+    }
+
+    public static boolean isInstanceOf(@NotNull PhpClass subjectClass, @NotNull PhpClass expectedClass) {
+
+        // we have equal class instance, on non multiple classes with same name fallback to namespace and classname
+        if (subjectClass == expectedClass || PhpElementsUtil.isEqualClassName(subjectClass, expectedClass)) {
+            return true;
+        }
+
+        if (expectedClass.isInterface()) {
+            return isImplementationOfInterface(subjectClass, expectedClass);
+        }
+
+        if (null == subjectClass.getSuperClass()) {
+            return false;
+        }
+
+        return isInstanceOf(subjectClass.getSuperClass(), expectedClass);
+    }
+//
+    public static boolean isCallTo(Method e, String ClassInterfaceName, String methodName) {
+
+        // we need a full fqn name
+        if(ClassInterfaceName.contains("\\") && !ClassInterfaceName.startsWith("\\")) {
+            ClassInterfaceName = "\\" + ClassInterfaceName;
+        }
+
+        return isCallTo(e, new Method[] {
+                getInterfaceMethod(e.getProject(), ClassInterfaceName, methodName),
+                getClassMethod(e.getProject(), ClassInterfaceName, methodName),
+        });
+    }
+}


### PR DESCRIPTION
This adds a TypeProvider, so unresolved method calls to stub objects don't show up yellow in editor.

Basically the "returned type" of `getMock`, `prophesize` and so on, is the standard Mock class from PHPUnit plus the actual mocked class from user code. So you get full autocompletion, reference/goto, etc.

**Without TypeProvider:**
![image](https://cloud.githubusercontent.com/assets/4896363/12079946/4b1c197c-b24b-11e5-8a6c-a4e59b3bd2ba.png)

**With TypeProvider:**
![image](https://cloud.githubusercontent.com/assets/4896363/12079885/98d3b2b2-b249-11e5-8677-f1273fcd305d.png)

_It also works, when you pass the mocked object to other methods expecting the mocked class:_

![image](https://cloud.githubusercontent.com/assets/4896363/12079952/97decfc0-b24b-11e5-806b-3a27fafd706d.png)

![image](https://cloud.githubusercontent.com/assets/4896363/12079955/ad38738a-b24b-11e5-8985-d4f30c90d16a.png)

This implementation works similar like the `$container->get('service_id')` in Symfony Plugin and was my base inspiration for that.
I took some Util classes and methods from https://github.com/Haehnchen/idea-php-symfony2-plugin. Hope that's ok @Haehnchen ?

This solves #5 
