### PR TITLE
Added completion/reference support for MockObject's 'method' calls

### DIFF
--- a/src/com/phpuaca/filter/FilterFactory.java
+++ b/src/com/phpuaca/filter/FilterFactory.java
@@ -24,6 +24,7 @@ final public class FilterFactory {
                 .add(new FilterConfigItem("PHPUnit_Framework_TestCase", "getMockForAbstractClass", 7, MockBuilderFilter.class))
                 .add(new FilterConfigItem("PHPUnit_Framework_TestCase", "getMockForTrait", 7, MockBuilderFilter.class))
                 .add(new FilterConfigItem("PHPUnit_Framework_MockObject_Builder_InvocationMocker", "method", 1, InvocationMockerFilter.class))
+                .add(new FilterConfigItem("PHPUnit_Framework_MockObject_MockObject", "method", 1, InvocationMockerFilter.class))
                 .add(new FilterConfigItem("MethodMock", "resetMethodCalledStack", 2, MethodMockFilter.class))
                 .add(new FilterConfigItem("MethodMock", "getCalledArgs", 2, MethodMockFilter.class))
                 .add(new FilterConfigItem("MethodMock", "isMethodCalled", 2, MethodMockFilter.class))


### PR DESCRIPTION
According to the PHPUnit manual, instead of this call ...

``` php
$mock->expects($this->any())->method('method_name')->will...
```

... the following can be used:

``` php
$mock->method('method_name')->will...
```

(see https://phpunit.de/manual/5.1/en/test-doubles.html#test-doubles.stubs.examples.StubTest.php)

The `method` method does not actually exist (magic method), but is defined in `PHPUnit_Framework_MockObject_MockObject` via phpdoc. Though this is not a problem here. PhpStorm autocompletes `$mock->|`. The only missing glue here is support for autocomplete and reference from your plugin inside the 'method_name' parameter, which I added as `FilterConfigItem`.
